### PR TITLE
Move to new result service

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -33,12 +33,14 @@ const commands = {
   },
   smorgesbord: {
     command: "!smorgesbord",
+    alternativeCommand: "!rank",
     helpText: "Get a cool smorgesbord.",
     exampleUsage:
       "!smorgesbord [ vinst/percent/total ] [ gameId ?] [ number of peoples ?]",
   },
   help: {
     command: "!helpame",
+    alternativeCommand: "!help",
     helpText: "Elvis flexes his abilities in front of everyone.",
     exampleUsage: "!helpame",
   },

--- a/commands.js
+++ b/commands.js
@@ -1,42 +1,52 @@
 //@ts-check
 
 const commands = {
-    pang: {
-        command:'pang!',
-        helpText: 'Elvis loads the gun and shows the people in the voice channel whats what',
-        example: 'pang! - person who requests this display of arnament needs to be in a voice channel'
-    },
-    listGames: {
-        command:'!giveGames',
-        helpText: 'Elvis will consult the archives and list every game he has',
-        example: '!giveGames'
-    },
-    role:{
-        command: 'roll',
-        alternativeCommand: 'role',
-        helpText: 'Record your role preferences Claes has examples or some stuff like that',
-        example: 'call Claes'
-    },
-    stat: {
-        command: '!stat',
-        helpText: 'Elvis will assist Clam with recording some stats for a game that was played and good Laggan member has honourably or dishonourably won.',
-        example: '!stat [gameId], [matchId ?]'
-    },
-    pobeditel:{
-        command: '!победител',
-        helpText: 'Roll d20 for ego inflate/bruise.',
-        example: '!победител [ discordUser ] [ gameId ?]'
-     },
-     smorgesbord: {
-         command: '!smorgesbord',
-         helpText: 'Get a cool smorgesbord.',
-         exampleUsage: '!smorgesbord [ vinst/percent/total ] [ gameId ?] [ number of peoples ?]'
-     },
-     help: {
-         command: '!helpame',
-         helpText: 'Elvis flexes his abilities in front of everyone.',
-         exampleUsage: '!helpame'
-     }
+  pang: {
+    command: "pang!",
+    helpText:
+      "Elvis loads the gun and shows the people in the voice channel whats what",
+    example:
+      "pang! - person who requests this display of arnament needs to be in a voice channel",
+  },
+  listGames: {
+    command: "!giveGames",
+    helpText: "Elvis will consult the archives and list every game he has",
+    example: "!giveGames",
+  },
+  role: {
+    command: "roll",
+    alternativeCommand: "role",
+    helpText:
+      "Record your role preferences Claes has examples or some stuff like that",
+    example: "call Claes",
+  },
+  stat: {
+    command: "!stat",
+    helpText:
+      "Elvis will assist Clam with recording some stats for a game that was played and good Laggan member has honourably or dishonourably won.",
+    example: "!stat [gameId], [matchId ?]",
+  },
+  pobeditel: {
+    command: "!победител",
+    helpText: "Roll d20 for ego inflate/bruise.",
+    example: "!победител [ discordUser ] [ gameId ?]",
+  },
+  smorgesbord: {
+    command: "!smorgesbord",
+    helpText: "Get a cool smorgesbord.",
+    exampleUsage:
+      "!smorgesbord [ vinst/percent/total ] [ gameId ?] [ number of peoples ?]",
+  },
+  help: {
+    command: "!helpame",
+    helpText: "Elvis flexes his abilities in front of everyone.",
+    exampleUsage: "!helpame",
+  },
+  alias: {
+    command: "!nick",
+    helpText: "Associate yourself with another nickname",
+    exampleUsage: "!nick bigboy bicboi largeboye",
+  },
 };
 
 module.exports = {

--- a/dublettKollare.js
+++ b/dublettKollare.js
@@ -4,12 +4,15 @@ module.exports = {
   dublettKollaren: async (matchIdData) => {
     const request = {
       baseURL: laggStatsBaseUrl,
-      url: "/result/all",
-      method: "get",
+      url: "/result/query",
+      method: "post",
       headers: {
         "Content-Type": "application/json",
       },
       responseType: "json",
+      data: {
+        args: [["matchId", "==", matchIdData]],
+      },
     };
     try {
       const res = await axios(request);

--- a/elevis.js
+++ b/elevis.js
@@ -56,34 +56,40 @@ function löftesKollaren(player) {
 client.on("messageCreate", async (meddelande) => {
   //=> är en funktion
 
+  const msg = meddelande.content;
+  const args = meddelande.content
+    .replace(/!.+?(\s|$)/, "")
+    .split(meddelande.content.includes(",") ? "," : " ")
+    .map((x) => x.trim().toLowerCase());
+
   if (!meddelande.author.bot) {
     switch (true) {
-      case meddelande.content.startsWith(commands.stat.command):
+      case msg.startsWith(commands.stat.command):
         await bigData.statCollector(meddelande);
         break;
 
-      case meddelande.content === commands.listGames.command:
-        console.log("Preparing to give games!");
+      case msg === commands.listGames.command:
         await bigData.listGames(meddelande);
         break;
 
-      case meddelande.content.startsWith(commands.pobeditel.command):
-        await bigData.gameWiener(meddelande);
+      case msg.startsWith(commands.pobeditel.command):
+        await bigData.gameWiener(meddelande, args);
         break;
 
-      case meddelande.content.startsWith(commands.smorgesbord.command):
-        await bigData.smorgesbord(meddelande, client);
+      case msg.startsWith(commands.smorgesbord.command) ||
+        msg.startsWith(commands.smorgesbord.alternativeCommand):
+        await bigData.smorgesbord(meddelande, args);
         break;
 
-      case meddelande.content.toLocaleLowerCase() === commands.help.command:
+      case msg.toLocaleLowerCase() === commands.help.command:
         await help(meddelande);
         break;
 
-      case meddelande.content.startsWith(commands.alias.command):
+      case msg.startsWith(commands.alias.command):
         await alias(meddelande);
         break;
 
-      case meddelande.content.startsWith("<@"):
+      case msg.startsWith("<@"):
         await motiveradVarning(meddelande);
         break;
 
@@ -94,14 +100,12 @@ client.on("messageCreate", async (meddelande) => {
         await elevRådsOrdförande(meddelande, brottet);
         break;
 
-      case meddelande.content.toLowerCase().startsWith(commands.role.command) ||
-        meddelande.content
-          .toLowerCase()
-          .startsWith(commands.role.alternativeCommand):
+      case msg.toLowerCase().startsWith(commands.role.command) ||
+        msg.toLowerCase().startsWith(commands.role.alternativeCommand):
         await roleAssign(meddelande);
         break;
 
-      case meddelande.content.toLocaleLowerCase() === commands.pang.command:
+      case msg.toLocaleLowerCase() === commands.pang.command:
         if (meddelande.member.voice.channel !== null) {
           await clickclackmotherfuckerthegunscomingoutyougottreesecondsFIVE(
             meddelande

--- a/elevis.js
+++ b/elevis.js
@@ -35,6 +35,7 @@ const {
 } = require("@discordjs/voice");
 const { commands } = require("./commands");
 const { help } = require("./help");
+const { addAliases } = require("./statRocket");
 
 let varningar = 0;
 
@@ -78,6 +79,10 @@ client.on("messageCreate", async (meddelande) => {
         await help(meddelande);
         break;
 
+      case meddelande.content.startsWith(commands.alias.command):
+        await alias(meddelande);
+        break;
+
       case meddelande.content.startsWith("<@"):
         await motiveradVarning(meddelande);
         break;
@@ -109,12 +114,25 @@ client.on("messageCreate", async (meddelande) => {
   }
 });
 
+async function alias(meddelande) {
+  const id = meddelande.author.id;
+  const allExceptFirst = meddelande.content.split(" ").slice(1);
+  const res = await addAliases(id, allExceptFirst);
+  if (res.status == "200") {
+    meddelande.react("👍");
+  } else {
+    meddelande.react("👎");
+  }
+  return;
+}
+
 async function motiveradVarning(meddelande) {
   const arr = meddelande.content.split(" ");
   const warned = arr[0];
   const command = arr[1];
+
   const orsak = arr.slice(2).join(" ");
-  if (!command.endsWith("arning")) {
+  if (!command?.endsWith("arning")) {
     return;
   }
   switch (command) {

--- a/statCollector.js
+++ b/statCollector.js
@@ -4,6 +4,7 @@ const {
   calculateGameWiener,
   getGames,
   getAllStatsFor,
+  sanitizeDiscordUserId,
 } = require("./wienerchickendinner.js");
 const { dublettKollaren } = require("./dublettKollare.js");
 const { matOchDryck } = require("./matOchDryck.js");
@@ -83,9 +84,9 @@ module.exports = {
   gameWiener: async (meddelande) => {
     const arguments = meddelande.content.split(" ");
 
-    let playerId = arguments[1];
+    let playerId = sanitizeDiscordUserId(arguments[1]);
     if (!playerId) {
-      playerId = `${meddelande.author.id}`;
+      playerId = meddelande.author.id;
     }
     const game = arguments[2] || "Dota 2";
 
@@ -283,7 +284,7 @@ function kapitalisera(string) {
 
 async function kapitalArray(array) {
   const kapitaliserad = array.map((namn) => {
-    return kapitalisera(namn);
+    return kapitalisera(sanitizeDiscordUserId(namn));
   });
   return kapitaliserad;
 }

--- a/statCollector.js
+++ b/statCollector.js
@@ -129,7 +129,7 @@ module.exports = {
           id: username,
           vinst: Number(curr.win),
           losses: Number(!curr.win),
-          percent: 0,
+          percent: 1000,
           total: 1,
           mmr: curr.win ? 25 : -25,
         });

--- a/statRocket.js
+++ b/statRocket.js
@@ -32,27 +32,19 @@ module.exports = {
       console.error(error);
     }
   },
+  addAliases: async (id, aliasArray) => {
+    return await axios({
+      baseURL: laggStatsBaseUrl,
+      url: "/alias",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      data: {
+        id: id,
+        aliases: aliasArray,
+      },
+      responseType: "json",
+    });
+  },
 };
-
-async function idRocket() {
-  //This is just for example if I need it later
-  //const arr = meddelande.content.toLocaleLowerCase().split(' ');
-  //const fejkLista = arr.slice(1);
-  let id = "207840759087497217";
-
-  let aliasesData = {
-    aliases: ["hugo", "snygghugo", "goblin", "goblinchair bladeborne"],
-    id: id,
-  };
-
-  const request = {
-    baseURL: laggStatsBaseUrl,
-    url: "/alias",
-    method: "post",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    data: aliasesData,
-    responseType: "json",
-  };
-}

--- a/wienerchickendinner.js
+++ b/wienerchickendinner.js
@@ -60,8 +60,13 @@ async function getAllStatsFor(gameFilter, idFilterArray) {
   return res.data;
 }
 
+function sanitizeDiscordUserId(userId) {
+  if (!userId?.startsWith("<@")) return userId;
+  return userId.replace(/<@!?/, "").replace(">", "");
+}
 module.exports = {
   calculateGameWiener,
   getGames,
   getAllStatsFor,
+  sanitizeDiscordUserId,
 };


### PR DESCRIPTION
## desc
Changes config.json URL to new endpoint.
Transforms old spammy solutions to ~1 call (improving response time by like 2 minutes)

We need to: Test locally and compare results, I have migrated all results as of 2022-04-17 05:30.


Key things to note: Users id is based on discord id (but can be entered as anything, but should ideally be discord user id) without the <@ >
Things are case sensitive (like games. "dota 2" != "Dota 2"). Maybe I should handle that in the result service so it just lowercases everything, but I don't like when you have things that rely on capital letters for its identity. Like if it was wc3 it would be DotA, which has a certain look to it. LEGO != lego, IKEA != ikea etc. 

## test
Things to test:

- save results (!stat)
- smorgesbord (!smorgesbord percent/vinst/total)
- get your own results (!победител)